### PR TITLE
feat:parent,child컬럼 추가 및 회원가입 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,11 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	implementation 'jakarta.validation:jakarta.validation-api:3.0.2'
+	implementation 'org.hibernate.validator:hibernate-validator:8.0.0.Final'
+
+	implementation 'org.springframework.boot:spring-boot-starter-security'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/swyp/playground/common/config/SecurityConfig.java
+++ b/src/main/java/com/swyp/playground/common/config/SecurityConfig.java
@@ -1,0 +1,28 @@
+package com.swyp.playground.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable()) // CSRF 임시로 비활성화
+                .authorizeHttpRequests(auth -> auth
+                        .anyRequest().permitAll() // 일단은 모든 요청 허용
+                );
+
+        return http.build();
+    }
+}

--- a/src/main/java/com/swyp/playground/common/domain/TypeChange.java
+++ b/src/main/java/com/swyp/playground/common/domain/TypeChange.java
@@ -1,0 +1,40 @@
+package com.swyp.playground.common.domain;
+
+import com.swyp.playground.domain.parent.domain.Parent;
+import com.swyp.playground.domain.parent.dto.req.ParentCreateReqDto;
+import com.swyp.playground.domain.parent.dto.res.ParentCreateResDto;
+import org.springframework.stereotype.Component;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Component
+public class TypeChange {
+
+    public Parent parentCreateReqDtoToParent(ParentCreateReqDto dto, String encodedPassword) {
+        return Parent.builder()
+                .name(dto.getName())
+                .email(dto.getEmail())
+                .password(encodedPassword)
+                .nickname(dto.getNickname())
+                .address(dto.getAddress())
+                .role(dto.getRole())
+                .birthDate(dto.getBirthDate())
+                .phoneNumber(dto.getPhoneNumber())
+                .childCount(dto.getChildCount())
+                .introduce(dto.getIntroduce())
+                .joinedAt(LocalDateTime.now())
+                .mannerTemp(BigDecimal.valueOf(50.0))
+                .build();
+    }
+
+    // Parent 엔티티를 ParentCreateResDto로 변환
+    public ParentCreateResDto parentToParentCreateResDto(Parent parent) {
+        return ParentCreateResDto.builder()
+                .id(parent.getParentId())
+                .name(parent.getName())
+                .email(parent.getEmail())
+                .nickname(parent.getNickname())
+                .build();
+    }
+}

--- a/src/main/java/com/swyp/playground/domain/child/controller/ChildController.java
+++ b/src/main/java/com/swyp/playground/domain/child/controller/ChildController.java
@@ -1,0 +1,5 @@
+package com.swyp.playground.domain.child.controller;
+
+public class ChildController {
+
+}

--- a/src/main/java/com/swyp/playground/domain/child/domain/Child.java
+++ b/src/main/java/com/swyp/playground/domain/child/domain/Child.java
@@ -1,0 +1,34 @@
+package com.swyp.playground.domain.child.domain;
+
+import com.swyp.playground.domain.parent.domain.Parent;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "child")
+@Getter
+@Setter
+public class Child {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "child_id")
+    private Long childId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_id", nullable = false)
+    private Parent parent;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "gender", nullable = false)
+    private ChildGenderType gender; // "남자" 또는 "여자"
+
+    @Column(name = "birth_date", nullable = false)
+    private LocalDate birthDate;
+
+    @Column(name = "age", nullable = false)
+    private Integer age;
+}

--- a/src/main/java/com/swyp/playground/domain/child/domain/ChildGenderType.java
+++ b/src/main/java/com/swyp/playground/domain/child/domain/ChildGenderType.java
@@ -1,0 +1,16 @@
+package com.swyp.playground.domain.child.domain;
+
+public enum ChildGenderType {
+    MALE("남자"),
+    FEMALE("여자");
+
+    private final String description;
+
+    ChildGenderType(String description) {
+        this.description = description;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+}

--- a/src/main/java/com/swyp/playground/domain/child/repository/ChildRepository.java
+++ b/src/main/java/com/swyp/playground/domain/child/repository/ChildRepository.java
@@ -1,0 +1,8 @@
+package com.swyp.playground.domain.child.repository;
+
+import com.swyp.playground.domain.child.domain.Child;
+import com.swyp.playground.domain.parent.domain.Parent;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChildRepository extends JpaRepository<Child,Long> {
+}

--- a/src/main/java/com/swyp/playground/domain/child/service/ChildService.java
+++ b/src/main/java/com/swyp/playground/domain/child/service/ChildService.java
@@ -1,0 +1,4 @@
+package com.swyp.playground.domain.child.service;
+
+public class ChildService {
+}

--- a/src/main/java/com/swyp/playground/domain/parent/controller/ParentController.java
+++ b/src/main/java/com/swyp/playground/domain/parent/controller/ParentController.java
@@ -1,14 +1,23 @@
 package com.swyp.playground.domain.parent.controller;
 
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import com.swyp.playground.domain.parent.dto.req.ParentCreateReqDto;
+import com.swyp.playground.domain.parent.dto.res.ParentCreateResDto;
+import com.swyp.playground.domain.parent.service.ParentService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/users")
+@RequestMapping("/oauth")
+@RequiredArgsConstructor
 public class ParentController {
-    @GetMapping("/test")
-    public String test(){
-        return "1123123213123123231231231";
+
+    private final ParentService parentService;
+
+    @PostMapping("/signup")
+    public ResponseEntity<ParentCreateResDto> signUp(@Validated @RequestBody ParentCreateReqDto request) {
+        ParentCreateResDto response = parentService.signUp(request);
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/swyp/playground/domain/parent/domain/Parent.java
+++ b/src/main/java/com/swyp/playground/domain/parent/domain/Parent.java
@@ -1,18 +1,22 @@
 package com.swyp.playground.domain.parent.domain;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.Table;
-import jakarta.persistence.Id;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Column;
+import com.swyp.playground.domain.child.domain.Child;
+import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Table(name = "parent")
 @Getter
 @Setter
+@Builder
 public class Parent {
 
     @Id
@@ -20,7 +24,57 @@ public class Parent {
     @Column(name = "parent_id")
     private Long parentId;
 
-    @Column
-    private Long name;
+    @Column(name = "name", length = 50, nullable = false)
+    private String name;
 
+    @Column(name = "email", length = 100, nullable = false, unique = true)
+    private String email;
+
+    @Column(name = "password", length = 255, nullable = false)
+    private String password;
+
+    @Column(name = "nickname", length = 20, nullable = false, unique = true)
+    private String nickname;
+
+    @Column(name = "address", length = 255, nullable = false)
+    private String address;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "role", nullable = false)
+    private ParentRoleType role; // "아빠" 또는 "엄마"
+
+    @Column(name = "birth_date", nullable = false)
+    private LocalDate birthDate;
+
+    @Column(name = "phone_number", length = 11, nullable = false, unique = true)
+    private String phoneNumber;
+
+    @Column(name = "child_count", nullable = false)
+    private Integer childCount;
+
+    @Column(name = "profile_img", length = 255)
+    private String profileImg;
+
+    @OneToMany(mappedBy = "parent", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Child> children = new ArrayList<>();
+
+    @Column(name = "introduce", length = 500)
+    private String introduce;
+
+    @Column(name = "joined_at", nullable = false)
+    private LocalDateTime joinedAt;
+
+    @Column(name = "manner_temp", precision = 5, scale = 2, nullable = false)
+    private BigDecimal mannerTemp;
+
+
+    public void addChild(Child child) {
+        child.setParent(this);
+        this.children.add(child);
+    }
+
+    public void removeChild(Child child) {
+        this.children.remove(child);
+        child.setParent(null);
+    }
 }

--- a/src/main/java/com/swyp/playground/domain/parent/domain/ParentRoleType.java
+++ b/src/main/java/com/swyp/playground/domain/parent/domain/ParentRoleType.java
@@ -1,0 +1,18 @@
+package com.swyp.playground.domain.parent.domain;
+
+
+public enum ParentRoleType {
+    FATHER("아빠"),
+    MOTHER("엄마");
+
+    private final String description;
+
+    ParentRoleType(String description) {
+        this.description = description;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+}
+

--- a/src/main/java/com/swyp/playground/domain/parent/dto/req/ParentCreateReqDto.java
+++ b/src/main/java/com/swyp/playground/domain/parent/dto/req/ParentCreateReqDto.java
@@ -1,0 +1,70 @@
+package com.swyp.playground.domain.parent.dto.req;
+
+import com.swyp.playground.domain.child.domain.ChildGenderType;
+import com.swyp.playground.domain.parent.domain.ParentRoleType;
+import jakarta.validation.constraints.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@Setter
+public class ParentCreateReqDto {
+
+    @NotBlank(message = "이름은 필수 입력 값입니다.")
+    private String name;
+
+    @NotBlank(message = "이메일은 필수 입력 값입니다.")
+    @Email(message = "유효한 이메일 형식이어야 합니다.")
+    private String email;
+
+    @NotBlank(message = "비밀번호는 필수 입력 값입니다.")
+    @Pattern(
+            regexp = "^(?=.*[A-Z])(?=.*[a-z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]{6,20}$",
+            message = "비밀번호는 6~20자 영문 대 소문자, 숫자, 특수문자를 포함해야 합니다."
+    )
+    private String password;
+
+    @NotBlank(message = "닉네임은 필수 입력 값입니다.")
+    private String nickname;
+
+    @NotBlank(message = "주소는 필수 입력 값입니다.")
+    private String address;
+
+    @NotNull(message = "보호자 역할은 필수 입력 값입니다.")
+    private ParentRoleType role;
+
+    @NotNull(message = "생년월일은 필수 입력 값입니다.")
+    private LocalDate birthDate;
+
+    @NotBlank(message = "소개는 필수 입력 값입니다.")
+    private String introduce;
+
+
+    @NotBlank(message = "전화번호는 필수 입력 값입니다.")
+    @Pattern(
+            regexp = "^01[0-9]{8,9}$",
+            message = "전화번호는 10~11자리 숫자로 입력하세요. 예: 01012345678"
+    )
+    private String phoneNumber;
+
+    @NotNull(message = "자녀 수는 필수 입력 값입니다.")
+    @Min(value = 1, message = "자녀 수는 최소 1명 이상이어야 합니다.")
+    private Integer childCount;
+
+    @Size(max = 5, message = "최대 5명의 자녀만 입력 가능합니다.")
+    private List<ChildDto> children;
+
+
+    @Getter
+    @Setter
+    public static class ChildDto {
+        @NotNull(message = "자녀의 성별은 필수 입력 값입니다.")
+        private ChildGenderType gender;
+
+        @NotNull(message = "자녀의 생년월일은 필수 입력 값입니다.")
+        private LocalDate birthDate;
+    }
+}

--- a/src/main/java/com/swyp/playground/domain/parent/dto/res/ParentCreateResDto.java
+++ b/src/main/java/com/swyp/playground/domain/parent/dto/res/ParentCreateResDto.java
@@ -1,0 +1,13 @@
+package com.swyp.playground.domain.parent.dto.res;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ParentCreateResDto {
+    private Long id;
+    private String name;
+    private String email;
+    private String nickname;
+}

--- a/src/main/java/com/swyp/playground/domain/parent/service/ParentService.java
+++ b/src/main/java/com/swyp/playground/domain/parent/service/ParentService.java
@@ -1,4 +1,26 @@
 package com.swyp.playground.domain.parent.service;
 
+import com.swyp.playground.common.domain.TypeChange;
+import com.swyp.playground.domain.parent.domain.Parent;
+import com.swyp.playground.domain.parent.dto.req.ParentCreateReqDto;
+import com.swyp.playground.domain.parent.dto.res.ParentCreateResDto;
+import com.swyp.playground.domain.parent.repository.ParentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
 public class ParentService {
+    private final ParentRepository parentRepository;
+    private final TypeChange typeChange;
+    private final PasswordEncoder passwordEncoder;
+
+    public ParentCreateResDto signUp(ParentCreateReqDto request) {
+        String encodedPassword = passwordEncoder.encode(request.getPassword());
+        Parent parent = typeChange.parentCreateReqDtoToParent(request, encodedPassword);
+        Parent savedParent = parentRepository.save(parent);
+
+        return typeChange.parentToParentCreateResDto(savedParent);
+    }
 }


### PR DESCRIPTION
1. parent,child컬럼 추가 
2. 회원가입기능 추가 http://localhost:8080/oauth/signup
{
  "name": "테스",
  "email": "test1@example.com",
  "password": "Password@123",
  "nickname": "길동이1",
  "address": "서울특별시 강남구",
  "role": "MOTHER",
  "birthDate": "1985-05-20",
  "phoneNumber": "01012345278",
  "childCount": 2,
  "introduce": "안녕하세요, 저는 두 아이의 아빠입니다.",
  "children": [
    {
      "gender": "MALE",
      "birthDate": "2015-03-01"
    },
    {
      "gender": "FEMALE",
      "birthDate": "2018-07-15"
    }
  ]
}


3. typechange를 통한 entity -> dto변환 (코드 간결화)
