### PR TITLE
feat:JWT추가, token, refresh 레디스저장, 로그아웃시 삭제

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,16 @@ dependencies {
 	implementation 'org.hibernate.validator:hibernate-validator:8.0.0.Final'
 
 	implementation 'org.springframework.boot:spring-boot-starter-security'
+
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'org.springframework.data:spring-data-redis:3.1.4'
+	implementation 'redis.clients:jedis:4.4.0'
+
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/swyp/playground/common/config/RedisConfig.java
+++ b/src/main/java/com/swyp/playground/common/config/RedisConfig.java
@@ -1,0 +1,26 @@
+package com.swyp.playground.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory("redis-container", 6379);
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(redisConnectionFactory());
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new StringRedisSerializer());
+        return template;
+    }
+}

--- a/src/main/java/com/swyp/playground/common/jwt/JwtAuthFilter.java
+++ b/src/main/java/com/swyp/playground/common/jwt/JwtAuthFilter.java
@@ -1,4 +1,48 @@
 package com.swyp.playground.common.jwt;
 
-public class JwtAuthFilter {
+import com.swyp.playground.common.redis.RedisService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+public class JwtAuthFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider tokenProvider;
+    private final RedisService redisService;
+
+    public JwtAuthFilter(JwtTokenProvider tokenProvider, RedisService redisService) {
+        this.tokenProvider = tokenProvider;
+        this.redisService = redisService;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+            throws ServletException, IOException {
+        String token = resolveToken(request);
+        if (token != null && tokenProvider.validateToken(token)) {
+            String email = tokenProvider.getEmailFromToken(token);
+            if (redisService.isTokenValid(token)) {
+                Authentication auth = new UsernamePasswordAuthenticationToken(
+                        new User(email, "", null), null, null);
+                SecurityContextHolder.getContext().setAuthentication(auth);
+            }
+        }
+        chain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
 }

--- a/src/main/java/com/swyp/playground/common/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/swyp/playground/common/jwt/JwtTokenProvider.java
@@ -1,4 +1,62 @@
 package com.swyp.playground.common.jwt;
 
+import io.jsonwebtoken.*;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.util.Date;
+
+@Component
 public class JwtTokenProvider {
+
+    @Value("${jwt.secret:default-secret-key}")
+    private String secretKey;
+
+    @Value("${jwt.expiration:3600000}")
+    private long expiration;
+
+    @Value("${jwt.refresh-expiration:604800000}")
+    private long refreshExpiration;
+
+
+    // JWT 생성
+    public String generateToken(String email) {
+        return Jwts.builder()
+                .setSubject(email)
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + expiration))
+                .signWith(SignatureAlgorithm.HS256, secretKey)
+                .compact();
+    }
+
+    public String generateRefreshToken(String email) {
+        return Jwts.builder()
+                .setSubject(email)
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + refreshExpiration))
+                .signWith(SignatureAlgorithm.HS256, secretKey)
+                .compact();
+    }
+
+    // JWT 검증
+    public boolean validateToken(String token) {
+        try {
+            System.out.println("Validating Token: " + token); // 토큰 출력
+            Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token);
+            return true;
+        } catch (JwtException | IllegalArgumentException e) {
+            System.out.println("Invalid Token: " + token);
+            e.printStackTrace();
+            return false;
+        }
+    }
+
+    // JWT에서 이메일 추출
+    public String getEmailFromToken(String token) {
+        Claims claims = Jwts.parser()
+                .setSigningKey(secretKey)
+                .parseClaimsJws(token)
+                .getBody();
+        return claims.getSubject();
+    }
 }

--- a/src/main/java/com/swyp/playground/common/redis/RedisService.java
+++ b/src/main/java/com/swyp/playground/common/redis/RedisService.java
@@ -1,4 +1,44 @@
 package com.swyp.playground.common.redis;
 
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.TimeUnit;
+
+@Service
 public class RedisService {
+
+    private final StringRedisTemplate redisTemplate;
+
+    public RedisService(StringRedisTemplate redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
+
+    // 토큰 저장
+    public void saveToken(String key, String value, long duration) {
+        redisTemplate.opsForValue().set(key, value, duration, TimeUnit.MILLISECONDS);
+    }
+
+    public void saveRefreshToken(String email, String refreshToken, long duration) {
+        String refreshKey = "refresh_" + email;
+        redisTemplate.opsForValue().set(refreshKey, refreshToken, duration, TimeUnit.MILLISECONDS);
+    }
+    // 토큰 조회
+    public String getToken(String key) {
+        return redisTemplate.opsForValue().get(key);
+    }
+
+    // 토큰 삭제
+    public void deleteToken(String key) {
+        redisTemplate.delete(key);
+    }
+    public void deleteRefreshToken(String email) {
+        String refreshKey = "refresh_" + email;
+        redisTemplate.delete(refreshKey);
+    }
+
+    // 토큰 검증
+    public boolean isTokenValid(String key) {
+        return redisTemplate.hasKey(key);
+    }
 }

--- a/src/main/java/com/swyp/playground/domain/login/controller/LoginController.java
+++ b/src/main/java/com/swyp/playground/domain/login/controller/LoginController.java
@@ -1,0 +1,32 @@
+package com.swyp.playground.domain.login.controller;
+
+import com.swyp.playground.domain.login.dto.req.LoginReqDto;
+import com.swyp.playground.domain.login.dto.res.LoginResDto;
+
+import com.swyp.playground.domain.login.service.LoginService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/oauth")
+public class LoginController {
+
+    private final LoginService loginService;
+
+
+    @PostMapping(value = "/login", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<LoginResDto> login(@Valid @RequestBody LoginReqDto loginReqDto) {
+        LoginResDto response = loginService.login(loginReqDto);
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout(@RequestHeader("Authorization") String token) {
+        loginService.logout(token.substring(7));
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/swyp/playground/domain/login/dto/req/LoginReqDto.java
+++ b/src/main/java/com/swyp/playground/domain/login/dto/req/LoginReqDto.java
@@ -1,0 +1,20 @@
+package com.swyp.playground.domain.login.dto.req;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class LoginReqDto {
+
+    @NotBlank(message = "이메일은 필수 입력 값입니다.")
+    @Email(message = "유효한 이메일 형식이어야 합니다.")
+    private String email;
+
+    @NotBlank(message = "비밀번호는 필수 입력 값입니다.")
+    private String password;
+}

--- a/src/main/java/com/swyp/playground/domain/login/dto/res/LoginResDto.java
+++ b/src/main/java/com/swyp/playground/domain/login/dto/res/LoginResDto.java
@@ -1,0 +1,12 @@
+package com.swyp.playground.domain.login.dto.res;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class LoginResDto {
+    private String email;
+    private String token;
+    private String refreshToken;
+}

--- a/src/main/java/com/swyp/playground/domain/login/service/LoginService.java
+++ b/src/main/java/com/swyp/playground/domain/login/service/LoginService.java
@@ -1,0 +1,62 @@
+package com.swyp.playground.domain.login.service;
+
+import com.swyp.playground.common.domain.TypeChange;
+import com.swyp.playground.common.jwt.JwtTokenProvider;
+import com.swyp.playground.common.redis.RedisService;
+import com.swyp.playground.domain.login.dto.req.LoginReqDto;
+import com.swyp.playground.domain.login.dto.res.LoginResDto;
+import com.swyp.playground.domain.parent.domain.Parent;
+import com.swyp.playground.domain.parent.repository.ParentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class LoginService {
+
+    private final JwtTokenProvider tokenProvider;
+    private final RedisService redisService;
+    private final PasswordEncoder passwordEncoder;
+    private final ParentRepository parentRepository;
+
+
+    public LoginResDto login(LoginReqDto loginReqDto) {
+        String email = loginReqDto.getEmail();
+        String password = loginReqDto.getPassword();
+
+        // DB에서 사용자 조회
+        Parent parent = parentRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 이메일입니다."));
+
+        // 비밀번호 비교
+        if (!passwordEncoder.matches(password, parent.getPassword())) {
+            throw new IllegalArgumentException("비밀번호가 올바르지 않습니다.");
+        }
+
+        // JWT 토큰 생성
+        String token = tokenProvider.generateToken(email);
+        String refreshToken = tokenProvider.generateRefreshToken(email);
+
+
+        // Redis에 토큰 저장
+        redisService.saveToken(token, email, 3600000); // 1시간 유지
+        redisService.saveToken("refresh_" + email, refreshToken, 604800000);  // 7일 유지
+
+        return LoginResDto.builder()
+                .email(email)
+                .token(token)
+                .refreshToken(refreshToken)
+                .build();
+    }
+
+    public void logout(String token) {
+        // Access Token 삭제
+        redisService.deleteToken(token);
+
+        // Refresh Token 삭제
+        String email = tokenProvider.getEmailFromToken(token);
+        String refreshTokenKey = "refresh_" + email; // Refresh Token 키 규칙
+        redisService.deleteToken(refreshTokenKey);
+    }
+}

--- a/src/main/java/com/swyp/playground/domain/parent/domain/Parent.java
+++ b/src/main/java/com/swyp/playground/domain/parent/domain/Parent.java
@@ -2,9 +2,7 @@ package com.swyp.playground.domain.parent.domain;
 
 import com.swyp.playground.domain.child.domain.Child;
 import jakarta.persistence.*;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -16,6 +14,8 @@ import java.util.List;
 @Table(name = "parent")
 @Getter
 @Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 @Builder
 public class Parent {
 

--- a/src/main/java/com/swyp/playground/domain/parent/repository/ParentRepository.java
+++ b/src/main/java/com/swyp/playground/domain/parent/repository/ParentRepository.java
@@ -4,6 +4,8 @@ import com.swyp.playground.domain.parent.domain.Parent;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.lang.reflect.Member;
+import java.util.Optional;
 
 public interface ParentRepository extends JpaRepository<Parent,Long> {
+    Optional<Parent> findByEmail(String email);
 }


### PR DESCRIPTION
1. 의존성 추가
Jwt, Valid, Redis, Jedis
2. 로그인,로그아웃 기능 추가
[POST]http://localhost:8080/oauth/login
Content-Type : application/json
Accept: application/jason
<img width="930" alt="image" src="https://github.com/user-attachments/assets/1fe58b13-675a-45e0-a72f-db90e8b081ad">


[POST]http://localhost:8080/oauth/logout
Authorization : Bearer <토큰>
<img width="929" alt="image" src="https://github.com/user-attachments/assets/0e527231-7f3d-4f6c-a1ba-214d8c47a81f">
변수로 ${{token}} 등록 후 테스트 진행하셔도 됩니다

3. 토큰값 레디스에 저장하여 유효성 검증
docker exec -it playground-redis-container-1 redis-cli
keys *
을 통해 확인가능

4. application.yml, docker-compose.yml 파일 디스코드에 추가하겠습니다.
