### PR TITLE
feat: auth 관련 파일 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,9 @@ dependencies {
 	//SMTP
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
 
+	//로그
+	implementation 'org.projectlombok:lombok:1.18.24'
+	annotationProcessor 'org.projectlombok:lombok:1.18.24'
 
 }
 

--- a/src/main/java/com/swyp/playground/common/config/SecurityConfig.java
+++ b/src/main/java/com/swyp/playground/common/config/SecurityConfig.java
@@ -36,13 +36,7 @@ public class SecurityConfig {
                                 "/swagger-resources/**",
                                 "/auth/signup",
                                 "/auth/login",
-                                "/auth/logout",
-                                "/find-friend/**",
-                                "/playgrounds/**",
-                                "/note/**",
-                                "/comment/**",
-                                "/auth/send-email").permitAll()
-                        .requestMatchers("/auth/users/**").authenticated()
+                                "/auth/logout").permitAll()
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(new JwtAuthFilter(tokenProvider, redisService),

--- a/src/main/java/com/swyp/playground/common/config/SwaggerConfig.java
+++ b/src/main/java/com/swyp/playground/common/config/SwaggerConfig.java
@@ -3,6 +3,8 @@ package com.swyp.playground.common.config;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -11,12 +13,27 @@ public class SwaggerConfig {
 
     @Bean
     public OpenAPI openAPI() {
+        SecurityScheme securityScheme = new SecurityScheme()
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("bearer")
+                .bearerFormat("JWT")
+                .name("Authorization")
+                .in(SecurityScheme.In.HEADER);
+
+        Components components = new Components()
+                .addSecuritySchemes("bearerAuth", securityScheme);
+
+        // Define Security Requirement
+        SecurityRequirement securityRequirement = new SecurityRequirement().addList("bearerAuth");
+
         Info info = new Info()
-                .title("Alioth Swagger")
-                .description("Alioth API Doc");
+                .title("Playground Swagger")
+                .description("Playground API Doc");
+
 
         return new OpenAPI()
-                .components(new Components())
+                .components(components)
+                .addSecurityItem(securityRequirement)
                 .info(info);
     }
 }

--- a/src/main/java/com/swyp/playground/common/redis/RedisService.java
+++ b/src/main/java/com/swyp/playground/common/redis/RedisService.java
@@ -15,14 +15,18 @@ public class RedisService {
     }
 
     // 토큰 저장
-    public void saveToken(String key, String value, long duration) {
-        redisTemplate.opsForValue().set(key, value, duration, TimeUnit.MILLISECONDS);
+    public void saveAccessToken(String email, String nickname, String accessToken, long duration) {
+        String accessKey = String.format("access_%s", email);
+        String accessValue = String.format("email:%s,nickname:%s,token:%s", email, nickname, accessToken);
+        redisTemplate.opsForValue().set(accessKey, accessValue, duration, TimeUnit.MILLISECONDS);
     }
 
+
     public void saveRefreshToken(String email, String refreshToken, long duration) {
-        String refreshKey = "refresh_" + email;
+        String refreshKey = String.format("refresh_%s", email);
         redisTemplate.opsForValue().set(refreshKey, refreshToken, duration, TimeUnit.MILLISECONDS);
     }
+
     // 토큰 조회
     public String getToken(String key) {
         return redisTemplate.opsForValue().get(key);

--- a/src/main/java/com/swyp/playground/domain/email/service/EmailServiceImpl.java
+++ b/src/main/java/com/swyp/playground/domain/email/service/EmailServiceImpl.java
@@ -23,7 +23,7 @@ public class EmailServiceImpl implements EmailService{
         MimeMessage  message = emailSender.createMimeMessage();
 
         message.addRecipients(MimeMessage.RecipientType.TO, to);//보내는 대상
-        message.setSubject("Well-Com 회원가입 이메일 인증");//제목
+        message.setSubject("Playgroud 본인확인 인증");//제목
 
         String msgg="";
         msgg+= "<div style='margin:100px;'>";
@@ -31,8 +31,8 @@ public class EmailServiceImpl implements EmailService{
         msgg+= "<br>";
 //        msgg+= "<p>아래 코드를 회원가입 창으로 돌아가 입력해주세요<p>";
 //        msgg+= "<br>";
-        msgg+= "<p>감사합니다!<p>";
-        msgg+= "<br>";
+//        msgg+= "<p>감사합니다!<p>";
+//        msgg+= "<br>";
         msgg+= "<div align='center' style='border:1px solid black; font-family:verdana';>";
         msgg+= "<h3 style='color:blue;'>회원가입 인증 코드입니다.</h3>";
         msgg+= "<div style='font-size:130%'>";

--- a/src/main/java/com/swyp/playground/domain/login/controller/LoginController.java
+++ b/src/main/java/com/swyp/playground/domain/login/controller/LoginController.java
@@ -1,5 +1,6 @@
 package com.swyp.playground.domain.login.controller;
 
+import com.swyp.playground.common.jwt.JwtTokenProvider;
 import com.swyp.playground.domain.login.dto.req.LoginReqDto;
 import com.swyp.playground.domain.login.dto.res.LoginResDto;
 
@@ -10,12 +11,15 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.Map;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/auth")
 public class LoginController {
 
     private final LoginService loginService;
+    private final JwtTokenProvider tokenProvider;
 
 
     @PostMapping(value = "/login", produces = MediaType.APPLICATION_JSON_VALUE)
@@ -28,5 +32,17 @@ public class LoginController {
     public ResponseEntity<Void> logout(@RequestHeader("Authorization") String token) {
         loginService.logout(token.substring(7));
         return ResponseEntity.ok().build();
+    }
+    @GetMapping("/islogin")
+    public ResponseEntity<Map<String, String>> getUserInfo(@RequestHeader("Authorization") String token) {
+        String cleanToken = token.substring(7); // "Bearer " 제거
+        String email = tokenProvider.getEmailFromToken(cleanToken);
+        String nickname = tokenProvider.getNicknameFromToken(cleanToken);
+
+        Map<String, String> userInfo = Map.of(
+                "email", email,
+                "nickname", nickname
+        );
+        return ResponseEntity.ok(userInfo);
     }
 }

--- a/src/main/java/com/swyp/playground/domain/login/dto/res/LoginResDto.java
+++ b/src/main/java/com/swyp/playground/domain/login/dto/res/LoginResDto.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 @Getter
 public class LoginResDto {
     private String email;
+    private String nickname;
     private String token;
     private String refreshToken;
 }

--- a/src/main/java/com/swyp/playground/domain/parent/controller/ParentController.java
+++ b/src/main/java/com/swyp/playground/domain/parent/controller/ParentController.java
@@ -6,6 +6,7 @@ import com.swyp.playground.domain.parent.dto.req.ParentCreateReqDto;
 import com.swyp.playground.domain.parent.dto.req.ParentUpdateReqDto;
 import com.swyp.playground.domain.parent.dto.res.ParentCreateResDto;
 import com.swyp.playground.domain.parent.service.ParentService;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -26,17 +27,21 @@ public class ParentController {
         ParentCreateResDto response = parentService.signUp(request);
         return ResponseEntity.ok(response);
     }
+    @SecurityRequirement(name = "bearerAuth")
     @GetMapping("/users/{id}")
     public ResponseEntity<ParentCreateResDto> getParentById(@PathVariable Long id){
         ParentCreateResDto response = parentService.getParentById(id);
         return ResponseEntity.ok(response);
     }
+    @SecurityRequirement(name = "bearerAuth")
     @PatchMapping("/users/edit/{id}")
     public ResponseEntity<ParentCreateResDto> updateParent(@PathVariable Long id,
                                                            @Validated @RequestBody ParentUpdateReqDto request) {
         ParentCreateResDto response = parentService.updateParent(id, request);
         return ResponseEntity.ok(response);
     }
+
+    @SecurityRequirement(name = "bearerAuth")
     @GetMapping("/users/all")
     public ResponseEntity<List<ParentCreateResDto>> getAllParents() {
         List<ParentCreateResDto> response = parentService.getAllParents();


### PR DESCRIPTION
1. token에 nickname정보 추가
`    public String getNicknameFromToken(String token) {
        Claims claims = Jwts.parser()
                .setSigningKey(secretKey)
                .parseClaimsJws(token)
                .getBody();
        return claims.get("nickname", String.class);
    }`
3. security config 회원가입, 로그인, swagger제외 전부 인증요구

5. swagger에서 인증이 필요한 부분 required 표시
@SecurityRequirement(name = "bearerAuth")
해당 api에 어노테이션만 추가하시면 됩니다.

7. redis에 토큰 저장시, 저장 유형 통일
    public void saveAccessToken(String email, String nickname, String accessToken, long duration) {
        String accessKey = String.format("access_%s", email);
        String accessValue = String.format("email:%s,nickname:%s,token:%s", email, nickname, accessToken);
        redisTemplate.opsForValue().set(accessKey, accessValue, duration, TimeUnit.MILLISECONDS);
    }


    public void saveRefreshToken(String email, String refreshToken, long duration) {
        String refreshKey = String.format("refresh_%s", email);
        redisTemplate.opsForValue().set(refreshKey, refreshToken, duration, TimeUnit.MILLISECONDS);
    }

9. 로그아웃 로직 수정 (기존 토큰 삭제 안되던 부분 보안)
Redis에 저장할때 토큰 형식과 로그아웃시 토큰 형식이 달라 로그아웃시 토큰 삭제가 불가능했음
(그래서 매칭이 안되서 불러오지 못하는거였음)
토큰 형식을 맞춤.
String accessKey = String.format("access_%s", email);
