### PR TITLE
feat:이메일 입력시 초기화된 비밀번호 전송

### DIFF
--- a/src/main/java/com/swyp/playground/common/config/SecurityConfig.java
+++ b/src/main/java/com/swyp/playground/common/config/SecurityConfig.java
@@ -36,7 +36,8 @@ public class SecurityConfig {
                                 "/swagger-resources/**",
                                 "/auth/signup",
                                 "/auth/login",
-                                "/auth/logout").permitAll()
+                                "/auth/reset-password"
+                                ).permitAll()
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(new JwtAuthFilter(tokenProvider, redisService),

--- a/src/main/java/com/swyp/playground/domain/email/controller/EmailController.java
+++ b/src/main/java/com/swyp/playground/domain/email/controller/EmailController.java
@@ -2,10 +2,12 @@ package com.swyp.playground.domain.email.controller;
 
 import com.swyp.playground.common.response.CommonResponse;
 import com.swyp.playground.domain.email.service.EmailService;
+import com.swyp.playground.domain.parent.domain.Parent;
 import com.swyp.playground.domain.parent.repository.ParentRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -18,14 +20,22 @@ public class EmailController {
 
     private final EmailService emailService;
     private final ParentRepository parentRepository;
+    private final PasswordEncoder passwordEncoder;
 
-    @PostMapping("/send-email")
-    public ResponseEntity<CommonResponse> emailConfirm(@RequestParam(value = "email") String email) throws Exception {
-        if(parentRepository.findByEmail(email).isPresent()){
-            return ResponseEntity.ok(new CommonResponse(HttpStatus.BAD_REQUEST, "중복 이메일 발생", ""));
-        }
-        String confirm = emailService.sendSimpleMessage(email);
 
-        return ResponseEntity.ok(new CommonResponse(HttpStatus.OK, "메일 발송 성공", confirm));
+    @PostMapping("/reset-password")
+    public ResponseEntity<CommonResponse> resetPassword(@RequestParam(value = "email") String email) throws Exception {
+        // 이메일이 존재하지 않으면 에러 반환
+        Parent parent = parentRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("등록되지 않은 이메일입니다."));
+
+        // 새 비밀번호 생성 및 이메일 발송
+        String newPassword = emailService.sendPasswordResetEmail(email);
+
+        // 데이터베이스에 새 비밀번호 저장
+        parent.setPassword(passwordEncoder.encode(newPassword));
+        parentRepository.save(parent);
+
+        return ResponseEntity.ok(new CommonResponse(HttpStatus.OK, "비밀번호 초기화 완료. 이메일을 확인하세요.", null));
     }
 }

--- a/src/main/java/com/swyp/playground/domain/email/service/EmailService.java
+++ b/src/main/java/com/swyp/playground/domain/email/service/EmailService.java
@@ -1,5 +1,5 @@
 package com.swyp.playground.domain.email.service;
 
 public interface EmailService {
-    String sendSimpleMessage(String to)throws Exception;
+    String sendPasswordResetEmail(String to)throws Exception;
 }

--- a/src/main/java/com/swyp/playground/domain/login/dto/req/LoginReqDto.java
+++ b/src/main/java/com/swyp/playground/domain/login/dto/req/LoginReqDto.java
@@ -2,6 +2,7 @@ package com.swyp.playground.domain.login.dto.req;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
@@ -12,9 +13,16 @@ import lombok.Setter;
 public class LoginReqDto {
 
     @NotBlank(message = "이메일은 필수 입력 값입니다.")
-    @Email(message = "유효한 이메일 형식이어야 합니다.")
+    @Pattern(
+            regexp = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,6}$",
+            message = "유효한 이메일 형식이어야 합니다."
+    )
     private String email;
 
     @NotBlank(message = "비밀번호는 필수 입력 값입니다.")
+    @Pattern(
+            regexp = "^(?=.*[A-Z])(?=.*[a-z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]{6,20}$",
+            message = "비밀번호는 6~20자 영문 대 소문자, 숫자, 특수문자를 포함해야 합니다."
+    )
     private String password;
 }

--- a/src/main/java/com/swyp/playground/domain/parent/controller/ParentController.java
+++ b/src/main/java/com/swyp/playground/domain/parent/controller/ParentController.java
@@ -47,6 +47,8 @@ public class ParentController {
         List<ParentCreateResDto> response = parentService.getAllParents();
         return ResponseEntity.ok(response);
     }
+
+    @SecurityRequirement(name = "bearerAuth")
     @PostMapping("/users/delete/{id}")
     public ResponseEntity<Void> deleteParent(@PathVariable Long id) {
         parentService.deleteParentById(id);

--- a/src/main/java/com/swyp/playground/domain/parent/repository/ParentRepository.java
+++ b/src/main/java/com/swyp/playground/domain/parent/repository/ParentRepository.java
@@ -2,8 +2,17 @@ package com.swyp.playground.domain.parent.repository;
 
 import com.swyp.playground.domain.parent.domain.Parent;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
 import java.util.Optional;
 
 public interface ParentRepository extends JpaRepository<Parent,Long> {
     Optional<Parent> findByEmail(String email);
+
+    @Modifying
+    @Query("UPDATE Parent p SET p.password = :password WHERE p.email = :email")
+    void updatePasswordByEmail(@Param("email") String email, @Param("password") String password);
+
 }

--- a/src/main/java/com/swyp/playground/domain/parent/service/ParentService.java
+++ b/src/main/java/com/swyp/playground/domain/parent/service/ParentService.java
@@ -65,4 +65,11 @@ public class ParentService {
                 .orElseThrow(() -> new IllegalArgumentException("해당 사용자를 찾을 수 없습니다: " + id));
         parentRepository.deleteById(id);
     }
+    public void resetPassword(String email, String newPassword) {
+        Parent parent = parentRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("해당 이메일을 가진 사용자가 존재하지 않습니다: " + email));
+
+        String encodedPassword = passwordEncoder.encode(newPassword);
+        parentRepository.updatePasswordByEmail(email, encodedPassword);
+    }
 }


### PR DESCRIPTION
1. securityconfig 수정
비밀번호 초기화 앤드포인트 추가
2. 기존 회원가입 인증 로직 삭제하고 리셋 로직 추가
3. 회원가입 시, 비밀번호 형식에 맞춰서, 로그인시에도 같은 형식으로, 초기화도 같은 형식으로 맞춤