### PR TITLE
Auth/user v11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,8 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok:1.18.24'
 
 	implementation 'software.amazon.awssdk:s3:2.20.0'
+
+	implementation 'com.fasterxml.jackson.core:jackson-databind'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/swyp/playground/common/S3/ProfileController.java
+++ b/src/main/java/com/swyp/playground/common/S3/ProfileController.java
@@ -11,18 +11,18 @@ import org.springframework.web.multipart.MultipartFile;
 @RequestMapping("/api/parent")
 @RequiredArgsConstructor
 public class ProfileController {
-
-    private final ParentService parentService;
-
-    @PostMapping("/{parentId}/upload-profile")
-    public ResponseEntity<String> uploadProfileImage(
-            @PathVariable Long parentId,
-            @RequestParam("file") MultipartFile file) {
-        try {
-            String fileUrl = parentService.uploadProfileImage(parentId, file);
-            return ResponseEntity.ok(fileUrl); // 업로드된 이미지 URL 반환
-        } catch (Exception e) {
-            return ResponseEntity.status(500).body("이미지 업로드 실패: " + e.getMessage());
-        }
-    }
 }
+//    private final ParentService parentService;
+
+//    @PostMapping("/{parentId}/upload-profile")
+//    public ResponseEntity<String> uploadProfileImage(
+//            @PathVariable Long parentId,
+//            @RequestParam("file") MultipartFile file) {
+//        try {
+//            String fileUrl = parentService.updateParent(parentId,);
+//            return ResponseEntity.ok(fileUrl); // 업로드된 이미지 URL 반환
+//        } catch (Exception e) {
+//            return ResponseEntity.status(500).body("이미지 업로드 실패: " + e.getMessage());
+//        }
+//    }
+//}

--- a/src/main/java/com/swyp/playground/common/domain/TypeChange.java
+++ b/src/main/java/com/swyp/playground/common/domain/TypeChange.java
@@ -1,5 +1,7 @@
 package com.swyp.playground.common.domain;
 
+import com.swyp.playground.domain.child.domain.Child;
+import com.swyp.playground.domain.child.dto.req.ChildUpdateReqDto;
 import com.swyp.playground.domain.parent.domain.Parent;
 import com.swyp.playground.domain.parent.dto.req.ParentCreateReqDto;
 import com.swyp.playground.domain.parent.dto.res.ParentCreateResDto;
@@ -7,6 +9,7 @@ import org.springframework.stereotype.Component;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.util.stream.Collectors;
 
 @Component
 public class TypeChange {
@@ -41,6 +44,30 @@ public class TypeChange {
                 .childCount(parent.getChildCount())
                 .birthDate(parent.getBirthDate())
                 .mannerTemp(parent.getMannerTemp())
+                .children(parent.getChildren().stream()
+                        .map(child -> ParentCreateResDto.ChildDto.builder()
+                                .id(child.getChildId())
+                                .gender(child.getGender())
+                                .birthDate(child.getBirthDate())
+                                .age(child.getAge())
+                                .build())
+                        .collect(Collectors.toList()))
                 .build();
     }
+    // ChildUpdateReqDto -> Child 엔티티 변환 (새로운 자녀 추가)
+    public Child childDtoToChild(ChildUpdateReqDto dto) {
+        return Child.builder()
+                .gender(dto.getGender())
+                .birthDate(dto.getBirthDate())
+                .age(dto.getAge())
+                .build();
+    }
+
+    // 기존 Child 엔티티 업데이트
+    public void updateChildFromDto(Child child, ChildUpdateReqDto dto) {
+        if (dto.getGender() != null) child.setGender(dto.getGender());
+        if (dto.getBirthDate() != null) child.setBirthDate(dto.getBirthDate());
+        if (dto.getAge() != null) child.setAge(dto.getAge());
+    }
+
 }

--- a/src/main/java/com/swyp/playground/domain/child/domain/Child.java
+++ b/src/main/java/com/swyp/playground/domain/child/domain/Child.java
@@ -3,8 +3,7 @@ package com.swyp.playground.domain.child.domain;
 import com.swyp.playground.domain.findfriend.domain.FindFriend;
 import com.swyp.playground.domain.parent.domain.Parent;
 import jakarta.persistence.*;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 
 import java.time.LocalDate;
 
@@ -12,6 +11,9 @@ import java.time.LocalDate;
 @Table(name = "child")
 @Getter
 @Setter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class Child {
 
     @Id

--- a/src/main/java/com/swyp/playground/domain/child/domain/ChildGenderType.java
+++ b/src/main/java/com/swyp/playground/domain/child/domain/ChildGenderType.java
@@ -1,5 +1,8 @@
 package com.swyp.playground.domain.child.domain;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+@JsonFormat(shape = JsonFormat.Shape.OBJECT)
 public enum ChildGenderType {
     MALE("남자"),
     FEMALE("여자");

--- a/src/main/java/com/swyp/playground/domain/child/dto/req/ChildUpdateReqDto.java
+++ b/src/main/java/com/swyp/playground/domain/child/dto/req/ChildUpdateReqDto.java
@@ -1,0 +1,17 @@
+package com.swyp.playground.domain.child.dto.req;
+
+
+import com.swyp.playground.domain.child.domain.ChildGenderType;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDate;
+
+@Getter
+@Setter
+public class ChildUpdateReqDto {
+    private Long id; // 자녀 ID (기존 자녀 수정 시 필요)
+    private ChildGenderType gender;
+    private LocalDate birthDate; // "남" 또는 "여"
+    private Integer age;
+}

--- a/src/main/java/com/swyp/playground/domain/parent/controller/ParentController.java
+++ b/src/main/java/com/swyp/playground/domain/parent/controller/ParentController.java
@@ -1,5 +1,6 @@
 package com.swyp.playground.domain.parent.controller;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.swyp.playground.common.response.CommonResponse;
 import com.swyp.playground.domain.parent.domain.Parent;
 import com.swyp.playground.domain.parent.dto.req.ParentCreateReqDto;
@@ -13,6 +14,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -22,32 +24,59 @@ import java.util.List;
 public class ParentController {
 
     private final ParentService parentService;
+    private final ObjectMapper objectMapper;
 
-    @PostMapping("/signup")
-    public ResponseEntity<ParentCreateResDto> signUp(@Validated @RequestBody ParentCreateReqDto request) {
-        ParentCreateResDto response = parentService.signUp(request);
-        return ResponseEntity.ok(response);
+    @PostMapping(value = "/signup", consumes = {"multipart/form-data"})
+    public ResponseEntity<ParentCreateResDto> signUp(
+            @RequestPart("data") String requestData,
+            @RequestPart(value = "file", required = false) MultipartFile profileImage) {
+        try {
+            // JSON 데이터를 DTO로 변환
+            ParentCreateReqDto request = objectMapper.readValue(requestData, ParentCreateReqDto.class);
+
+            if (profileImage != null) {
+                request.setProfileImage(profileImage);
+            }
+
+            ParentCreateResDto response = parentService.signUp(request);
+            return ResponseEntity.ok(response);
+        } catch (Exception e) {
+            return ResponseEntity.badRequest().body(null);
+        }
     }
+
     @SecurityRequirement(name = "bearerAuth")
     @GetMapping("/users/{id}")
     public ResponseEntity<ParentCreateResDto> getParentById(@PathVariable Long id){
         ParentCreateResDto response = parentService.getParentById(id);
         return ResponseEntity.ok(response);
     }
-    @SecurityRequirement(name = "bearerAuth")
-    @PatchMapping("/users/edit/{id}")
-    public ResponseEntity<?> updateParent(@PathVariable Long id,
-                                          @Validated @RequestBody ParentUpdateReqDto request,
-                                          @AuthenticationPrincipal User authenticatedUser) {
-        String authenticatedEmail = authenticatedUser.getUsername();
-        Parent parent = parentService.getParentEntityById(id);
-        if (!parent.getEmail().equals(authenticatedEmail)) {
-            return ResponseEntity.status(403).body("자신의 정보만 수정할 수 있습니다.");
-        }
+    @PatchMapping(value = "/users/edit/{id}", consumes = {"multipart/form-data"})
+    public ResponseEntity<?> updateParent(
+            @PathVariable Long id,
+            @RequestPart("data") String requestData,
+            @RequestPart(value = "file", required = false) MultipartFile profileImage,
+            @AuthenticationPrincipal User authenticatedUser) {
+        try {
+            // JSON 데이터를 DTO로 변환
+            ParentUpdateReqDto request = objectMapper.readValue(requestData, ParentUpdateReqDto.class);
 
-        ParentCreateResDto response = parentService.updateParent(id, request);
-        return ResponseEntity.ok(response);
+            String authenticatedEmail = authenticatedUser.getUsername();
+            Parent parent = parentService.getParentEntityById(id);
+            if (!parent.getEmail().equals(authenticatedEmail)) {
+                return ResponseEntity.status(403).body("자신의 정보만 수정할 수 있습니다.");
+            }
+
+            if (profileImage != null) {
+                request.setProfileImage(profileImage);
+            }
+            ParentCreateResDto response = parentService.updateParent(id, request);
+            return ResponseEntity.ok(response);
+        } catch (Exception e) {
+            return ResponseEntity.badRequest().body("Invalid request: " + e.getMessage());
+        }
     }
+
 
 
     @SecurityRequirement(name = "bearerAuth")

--- a/src/main/java/com/swyp/playground/domain/parent/controller/ParentController.java
+++ b/src/main/java/com/swyp/playground/domain/parent/controller/ParentController.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.User;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -35,11 +36,19 @@ public class ParentController {
     }
     @SecurityRequirement(name = "bearerAuth")
     @PatchMapping("/users/edit/{id}")
-    public ResponseEntity<ParentCreateResDto> updateParent(@PathVariable Long id,
-                                                           @Validated @RequestBody ParentUpdateReqDto request) {
+    public ResponseEntity<?> updateParent(@PathVariable Long id,
+                                          @Validated @RequestBody ParentUpdateReqDto request,
+                                          @AuthenticationPrincipal User authenticatedUser) {
+        String authenticatedEmail = authenticatedUser.getUsername();
+        Parent parent = parentService.getParentEntityById(id);
+        if (!parent.getEmail().equals(authenticatedEmail)) {
+            return ResponseEntity.status(403).body("자신의 정보만 수정할 수 있습니다.");
+        }
+
         ParentCreateResDto response = parentService.updateParent(id, request);
         return ResponseEntity.ok(response);
     }
+
 
     @SecurityRequirement(name = "bearerAuth")
     @GetMapping("/users/all")

--- a/src/main/java/com/swyp/playground/domain/parent/domain/Parent.java
+++ b/src/main/java/com/swyp/playground/domain/parent/domain/Parent.java
@@ -2,7 +2,6 @@ package com.swyp.playground.domain.parent.domain;
 
 import com.swyp.playground.domain.child.domain.Child;
 import com.swyp.playground.domain.findfriend.domain.FindFriend;
-import com.swyp.playground.domain.findfriend.domain.PlayHistory;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -43,7 +42,7 @@ public class Parent {
 
     @Enumerated(EnumType.STRING)
     @Column(name = "role", nullable = false)
-    private ParentRoleType role; // "아빠" 또는 "엄마"
+    private ParentRoleType role;
 
     @Column(name = "birth_date", nullable = false)
     private LocalDate birthDate;
@@ -58,7 +57,7 @@ public class Parent {
     private String profileImg;
 
     @OneToMany(mappedBy = "parent", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Child> children = new ArrayList<>();
+    private List<Child> children = new ArrayList<>(); // 리스트 초기화
 
     @Column(name = "introduce", length = 5000)
     private String introduce;
@@ -74,12 +73,17 @@ public class Parent {
     private FindFriend findFriend;
 
     public void addChild(Child child) {
+        if (this.children == null) {
+            this.children = new ArrayList<>();
+        }
         child.setParent(this);
         this.children.add(child);
     }
 
     public void removeChild(Child child) {
-        this.children.remove(child);
-        child.setParent(null);
+        if (this.children != null) {
+            this.children.remove(child);
+            child.setParent(null);
+        }
     }
 }

--- a/src/main/java/com/swyp/playground/domain/parent/dto/req/ParentCreateReqDto.java
+++ b/src/main/java/com/swyp/playground/domain/parent/dto/req/ParentCreateReqDto.java
@@ -5,6 +5,7 @@ import com.swyp.playground.domain.parent.domain.ParentRoleType;
 import jakarta.validation.constraints.*;
 import lombok.Getter;
 import lombok.Setter;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -60,7 +61,7 @@ public class ParentCreateReqDto {
     @Size(max = 5, message = "최대 5명의 자녀만 입력 가능합니다.")
     private List<ChildDto> children;
 
-
+    private MultipartFile profileImage;
     @Getter
     @Setter
     public static class ChildDto {

--- a/src/main/java/com/swyp/playground/domain/parent/dto/req/ParentUpdateReqDto.java
+++ b/src/main/java/com/swyp/playground/domain/parent/dto/req/ParentUpdateReqDto.java
@@ -6,6 +6,7 @@ import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
 import lombok.Setter;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -22,4 +23,6 @@ public class ParentUpdateReqDto {
     private String introduce;
 
     private List<ChildUpdateReqDto> children;
+
+    private MultipartFile profileImage;
 }

--- a/src/main/java/com/swyp/playground/domain/parent/dto/req/ParentUpdateReqDto.java
+++ b/src/main/java/com/swyp/playground/domain/parent/dto/req/ParentUpdateReqDto.java
@@ -1,10 +1,13 @@
 package com.swyp.playground.domain.parent.dto.req;
 
+import com.swyp.playground.domain.child.dto.req.ChildUpdateReqDto;
 import com.swyp.playground.domain.parent.domain.ParentRoleType;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
 import lombok.Setter;
+
+import java.util.List;
 
 @Getter
 @Setter
@@ -17,4 +20,6 @@ public class ParentUpdateReqDto {
     private String phoneNumber;
 
     private String introduce;
+
+    private List<ChildUpdateReqDto> children;
 }

--- a/src/main/java/com/swyp/playground/domain/parent/dto/res/ParentCreateResDto.java
+++ b/src/main/java/com/swyp/playground/domain/parent/dto/res/ParentCreateResDto.java
@@ -1,11 +1,13 @@
 package com.swyp.playground.domain.parent.dto.res;
 
+import com.swyp.playground.domain.child.domain.ChildGenderType;
 import com.swyp.playground.domain.parent.domain.ParentRoleType;
 import lombok.Builder;
 import lombok.Getter;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.util.List;
 
 @Getter
 @Builder
@@ -20,4 +22,14 @@ public class ParentCreateResDto {
     private ParentRoleType role;
     private Integer childCount;
     private BigDecimal mannerTemp;
+    private List<ChildDto> children; // 자녀 정보 추가
+
+    @Getter
+    @Builder
+    public static class ChildDto {
+        private Long id;
+        private ChildGenderType gender;
+        private LocalDate birthDate;
+        private Integer age;
+    }
 }

--- a/src/main/java/com/swyp/playground/domain/parent/repository/ParentRepository.java
+++ b/src/main/java/com/swyp/playground/domain/parent/repository/ParentRepository.java
@@ -15,4 +15,12 @@ public interface ParentRepository extends JpaRepository<Parent,Long> {
     @Query("UPDATE Parent p SET p.password = :password WHERE p.email = :email")
     void updatePasswordByEmail(@Param("email") String email, @Param("password") String password);
 
+    @Query("SELECT p FROM Parent p LEFT JOIN FETCH p.children WHERE p.parentId = :id")
+    Optional<Parent> findParentWithChildren(@Param("id") Long id);
+
+    @Query("SELECT CASE WHEN COUNT(p) > 0 THEN TRUE ELSE FALSE END FROM Parent p WHERE p.phoneNumber = :phoneNumber")
+    boolean isPhoneNumberDuplicate(@Param("phoneNumber") String phoneNumber);
+
+    Optional<Parent> findByPhoneNumber(String phoneNumber);
+
 }

--- a/src/main/java/com/swyp/playground/domain/parent/service/ParentService.java
+++ b/src/main/java/com/swyp/playground/domain/parent/service/ParentService.java
@@ -2,6 +2,8 @@ package com.swyp.playground.domain.parent.service;
 
 import com.swyp.playground.common.S3.S3Service;
 import com.swyp.playground.common.domain.TypeChange;
+import com.swyp.playground.domain.child.domain.Child;
+import com.swyp.playground.domain.child.dto.req.ChildUpdateReqDto;
 import com.swyp.playground.domain.parent.domain.Parent;
 import com.swyp.playground.domain.parent.dto.req.ParentCreateReqDto;
 import com.swyp.playground.domain.parent.dto.req.ParentUpdateReqDto;
@@ -10,12 +12,15 @@ import com.swyp.playground.domain.parent.repository.ParentRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.stream.Collectors;
 
 @Service
+@Transactional
 @RequiredArgsConstructor
 public class ParentService {
     private final ParentRepository parentRepository;
@@ -24,16 +29,44 @@ public class ParentService {
     private final S3Service s3Service;
 
     public ParentCreateResDto signUp(ParentCreateReqDto request) {
+        if (isPhoneNumberDuplicate(request.getPhoneNumber())) {
+            throw new IllegalArgumentException("이미 존재하는 전화번호입니다: " + request.getPhoneNumber());
+        }
+
         String encodedPassword = passwordEncoder.encode(request.getPassword());
         Parent parent = typeChange.parentCreateReqDtoToParent(request, encodedPassword);
-        Parent savedParent = parentRepository.save(parent);
 
+        if (request.getChildren() != null) {
+            request.getChildren().forEach(childDto -> {
+                Child child = Child.builder()
+                        .gender(childDto.getGender())
+                        .birthDate(childDto.getBirthDate())
+                        .age(LocalDate.now().getYear() - childDto.getBirthDate().getYear())
+                        .parent(parent)  // 자녀에 부모 설정
+                        .build();
+                parent.addChild(child);
+            });
+        }
+
+        Parent savedParent = parentRepository.save(parent);
         return typeChange.parentToParentCreateResDto(savedParent);
     }
+    private boolean isPhoneNumberDuplicate(String phoneNumber) {
+        return parentRepository.findByPhoneNumber(phoneNumber).isPresent();
+    }
 
+    // 생년월일로 나이 계산 메서드 추가
+    private int calculateAge(LocalDate birthDate) {
+        return LocalDate.now().getYear() - birthDate.getYear();
+    }
+
+    @Transactional
     public ParentCreateResDto getParentById(Long id){
-        Parent parent = parentRepository.findById(id)
+        Parent parent = parentRepository.findParentWithChildren(id)
                 .orElseThrow(() -> new IllegalArgumentException("해당 사용자를 찾을 수 없습니다: " + id));
+        List<Child> initializedChildren = parent.getChildren();
+        initializedChildren.size(); // 초기화 강제 수행
+
         return typeChange.parentToParentCreateResDto(parent);
     }
 
@@ -43,26 +76,58 @@ public class ParentService {
                 .map(typeChange::parentToParentCreateResDto)
                 .collect(Collectors.toList());
     }
+    @Transactional
     public ParentCreateResDto updateParent(Long id, ParentUpdateReqDto request) {
-        Parent parent = parentRepository.findById(id)
+        Parent parent = parentRepository.findParentWithChildren(id)
                 .orElseThrow(() -> new IllegalArgumentException("해당 사용자를 찾을 수 없습니다: " + id));
 
-        if (request.getNickname() != null) {
-            parent.setNickname(request.getNickname());
-        }
-        if (request.getAddress() != null) {
-            parent.setAddress(request.getAddress());
-        }
-        if (request.getPhoneNumber() != null) {
-            parent.setPhoneNumber(request.getPhoneNumber());
-        }
-        if (request.getIntroduce() != null) {
-            parent.setIntroduce(request.getIntroduce());
+        updateParentInfo(parent, request);
+
+        if (request.getChildren() != null) {
+            // 자녀 정보 업데이트
+            for (ChildUpdateReqDto childDto : request.getChildren()) {
+                if (childDto.getId() != null) {
+                    // 기존 자녀 업데이트
+                    Child existingChild = parent.getChildren().stream()
+                            .filter(c -> c.getChildId().equals(childDto.getId()))
+                            .findFirst()
+                            .orElseThrow(() -> new IllegalArgumentException("해당 자녀를 찾을 수 없습니다: " + childDto.getId()));
+                    typeChange.updateChildFromDto(existingChild, childDto);
+                } else {
+                    // 새 자녀 추가
+                    Child newChild = typeChange.childDtoToChild(childDto);
+                    parent.addChild(newChild);
+                }
+            }
         }
 
         Parent updatedParent = parentRepository.save(parent);
         return typeChange.parentToParentCreateResDto(updatedParent);
     }
+
+
+    private void updateParentInfo(Parent parent, ParentUpdateReqDto request) {
+        if (request.getNickname() != null) parent.setNickname(request.getNickname());
+        if (request.getAddress() != null) parent.setAddress(request.getAddress());
+        if (request.getPhoneNumber() != null) parent.setPhoneNumber(request.getPhoneNumber());
+        if (request.getIntroduce() != null) parent.setIntroduce(request.getIntroduce());
+    }
+
+    private void updateChildren(Parent parent, List<ChildUpdateReqDto> children) {
+        for (ChildUpdateReqDto childDto : children) {
+            if (childDto.getId() != null) {
+                Child existingChild = parent.getChildren().stream()
+                        .filter(c -> c.getChildId().equals(childDto.getId()))
+                        .findFirst()
+                        .orElseThrow(() -> new IllegalArgumentException("해당 자녀를 찾을 수 없습니다: " + childDto.getId()));
+                typeChange.updateChildFromDto(existingChild, childDto);
+            } else {
+                Child newChild = typeChange.childDtoToChild(childDto);
+                parent.addChild(newChild);
+            }
+        }
+    }
+
     public void deleteParentById(Long id) {
         parentRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("해당 사용자를 찾을 수 없습니다: " + id));
@@ -91,5 +156,10 @@ public class ParentService {
         } catch (Exception e) {
             throw new RuntimeException("이미지 업로드 실패: " + e.getMessage(), e);
         }
+    }
+
+    public Parent getParentEntityById(Long id) {
+        return parentRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("해당 사용자를 찾을 수 없습니다: " + id));
     }
 }


### PR DESCRIPTION
회원정보시 프로필 사진 수정할 수 있도록 로직 변경
# 본인이 아니면 프로필 수정 할 수 없음.

*포스트맨 테스트 방법

<img width="812" alt="image" src="https://github.com/user-attachments/assets/a1a7c703-80dc-4528-8e5f-4ef1a8beb92f">


{
    "nickname": "Updated Nickname",
    "address": "New Address",
    "phoneNumber": "01012345671",
    "introduce": "Updated introduction",
    "children": [
        {
            "id": 1,
            "gender": "MALE",
            "birthDate": "2015-06-01",
            "age": 8
        },
        {
            "gender": "FEMALE",
            "birthDate": "2018-09-10",
            "age": 5
        }
    ]
}

Form-data
data -> text -> 위에 json입력 ( 수정하고자 하는 정보들 )
data -> file -> 수정하고자 하는 파일 선택

최초 회원정보 디비 조회시
https://playground.kr.object.ncloudstorage.com/profiles/null_facebook-logo.png
수정후 회원정보  디비 조회시
https://playground.kr.object.ncloudstorage.com/profiles/1_%E1%84%89%E1%85%B3%E1%84%8F%E1%85%B3%E1%84%85%E1%85%B5%E1%86%AB%E1%84%89%E1%85%A3%E1%86%BA%202024-01-26%20%E1%84%8B%E1%85%A9%E1%84%8C%E1%85%A5%E1%86%AB%2010.48.13.png

