### PR TITLE
feat: 회원별 조회 및 회원 인증 구현

### DIFF
--- a/src/main/java/com/swyp/playground/domain/note/controller/NoteController.java
+++ b/src/main/java/com/swyp/playground/domain/note/controller/NoteController.java
@@ -3,12 +3,10 @@ package com.swyp.playground.domain.note.controller;
 import java.util.Date;
 import java.util.Calendar;
 import java.util.List;
-import java.util.Optional;
 import java.util.TimeZone;
 
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -23,7 +21,6 @@ import org.springframework.security.core.userdetails.User;
 
 import com.swyp.playground.domain.note.domain.Note;
 import com.swyp.playground.domain.note.dto.WriteNoteDto;
-import com.swyp.playground.common.redis.RedisService;
 
 import com.swyp.playground.domain.note.service.NoteService;
 
@@ -37,9 +34,6 @@ public class NoteController {
     @Autowired
     private NoteService noteService;
 
-    private RedisService redisService;
-
-    // -- GET --
     @GetMapping("/all")
     @SecurityRequirement(name="bearerAuth")
     public ResponseEntity<List<Note>> getAllNotes(@AuthenticationPrincipal User user) {
@@ -52,7 +46,6 @@ public class NoteController {
         return new ResponseEntity<Note>(noteService.getNoteById(id), HttpStatus.OK);
     }
 
-    // -- POST --
     @PostMapping
     @SecurityRequirement(name="bearerAuth")
     public ResponseEntity<Note> sendNote(@RequestBody WriteNoteDto writeNoteDto) {
@@ -80,13 +73,11 @@ public class NoteController {
             String email = user.getUsername();
             noteService.patchNoteById(id, newNote, email);
         } catch (Exception e) {
-            // 디버깅 처리
             System.err.println(e);
         }
         return ResponseEntity.ok("쪽지가 정상적으로 삭제되었습니다.");
     }
 
-    // -- DELETE --
     @DeleteMapping
     @SecurityRequirement(name="bearerAuth")
     public ResponseEntity<String> deleteNote(@RequestParam Long id, @AuthenticationPrincipal User user) {
@@ -94,7 +85,6 @@ public class NoteController {
         try {
             noteService.deleteNote(id, email);
         } catch (Exception e) {
-            // 디버깅 처리
             System.err.println(e);
         }
         return ResponseEntity.ok("쪽지가 정상적으로 삭제되었습니다.");

--- a/src/main/java/com/swyp/playground/domain/note/repository/NoteRepository.java
+++ b/src/main/java/com/swyp/playground/domain/note/repository/NoteRepository.java
@@ -1,9 +1,12 @@
 package com.swyp.playground.domain.note.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.swyp.playground.domain.note.domain.Note;
 
 public interface NoteRepository extends JpaRepository<Note, Long> {
-    
+    // 자신에게 온 쪽지 모두 조회
+    public List<Note> findAllByTargetId(String targetId);
 }

--- a/src/main/java/com/swyp/playground/domain/note/service/NoteService.java
+++ b/src/main/java/com/swyp/playground/domain/note/service/NoteService.java
@@ -9,12 +9,16 @@ import org.springframework.stereotype.Service;
 import com.swyp.playground.domain.note.domain.Note;
 import com.swyp.playground.domain.note.dto.WriteNoteDto;
 import com.swyp.playground.domain.note.repository.NoteRepository;
+import com.swyp.playground.domain.parent.repository.ParentRepository;
 
 @Service
 public class NoteService {
     
     @Autowired
     private NoteRepository noteRepository;
+
+    @Autowired
+    private ParentRepository parentRepository;
     
     /* -- POST -- */
     public Note sendNote(Note note) {
@@ -22,34 +26,43 @@ public class NoteService {
     }
 
     /* -- GET -- */
-    public List<Note> getAllNotes() {
-        return noteRepository.findAll();
+    public List<Note> getAllNotes(String email) {
+        String targetId = parentRepository.findByEmail(email).get().getNickname();
+        return noteRepository.findAllByTargetId(targetId);
     }
 
     public Note getNoteById(Long id) {
-        
         return noteRepository.findById(id)
         .orElseThrow(() -> new NullPointerException("해당 쪽지가 존재하지 않습니다."));
     }
 
     /* -- UPDATE -- */
-    public void patchNoteById(Long id, WriteNoteDto newNote) {
+    public void patchNoteById(Long id, WriteNoteDto newNote, String email) {
         try {
             Note prevNote = noteRepository.findById(id)
                             .orElseThrow(() -> new NullPointerException("해당 쪽지가 존재하지 않습니다."));
-            
-            if (prevNote.getContent() != newNote.getContent()) {
-                prevNote.setContent(newNote.getContent());
+            // 실제 작성자 검증 로직
+            if (prevNote.getWrittenBy() == parentRepository.findByEmail(email).get().getNickname()) {
+                if (prevNote.getContent() != newNote.getContent()) { // 변경사항 있을 시에만 업데이트
+                    prevNote.setContent(newNote.getContent());
+                    noteRepository.save(prevNote);
+                }
+            } else {
+                throw new IllegalAccessError("작성자만 수정할 수 있습니다.");
             }
-            
-            noteRepository.save(prevNote);
         } catch (Exception e) {
             System.err.println(e);
         }
     }
 
     /* -- DELETE -- */
-    public void deleteNote(Long id) {
-        noteRepository.deleteById(id);
+    public void deleteNote(Long id, String email) {
+        String nickname = parentRepository.findByEmail(email).get().getNickname();
+        String writtenBy = noteRepository.findById(id).get().getWrittenBy();
+        if (nickname.equals(writtenBy)) {
+            noteRepository.deleteById(id);
+        } else {
+            throw new IllegalArgumentException("작성자만 삭제할 수 있습니다.");
+        }
     }
 }

--- a/src/main/java/com/swyp/playground/domain/note/service/NoteService.java
+++ b/src/main/java/com/swyp/playground/domain/note/service/NoteService.java
@@ -20,12 +20,10 @@ public class NoteService {
     @Autowired
     private ParentRepository parentRepository;
     
-    /* -- POST -- */
     public Note sendNote(Note note) {
         return noteRepository.save(note);
     }
 
-    /* -- GET -- */
     public List<Note> getAllNotes(String email) {
         String targetId = parentRepository.findByEmail(email).get().getNickname();
         return noteRepository.findAllByTargetId(targetId);
@@ -36,7 +34,6 @@ public class NoteService {
         .orElseThrow(() -> new NullPointerException("해당 쪽지가 존재하지 않습니다."));
     }
 
-    /* -- UPDATE -- */
     public void patchNoteById(Long id, WriteNoteDto newNote, String email) {
         try {
             Note prevNote = noteRepository.findById(id)
@@ -55,7 +52,6 @@ public class NoteService {
         }
     }
 
-    /* -- DELETE -- */
     public void deleteNote(Long id, String email) {
         String nickname = parentRepository.findByEmail(email).get().getNickname();
         String writtenBy = noteRepository.findById(id).get().getWrittenBy();


### PR DESCRIPTION
- 회원의 로그인 상태로부터 아이디를 불러오고 해당 아이디에 맞는 쪽지 목록 반환
- 쪽지 삭제 시, 요청회원과 기존유저를 비교하여 해당하는 회원만 삭제 및 업로드가 가능하도록 구현