### PR TITLE
feat:비밀번호 변경 로직추가

### DIFF
--- a/src/main/java/com/swyp/playground/domain/parent/dto/req/ParentPasswordChangeReqDto.java
+++ b/src/main/java/com/swyp/playground/domain/parent/dto/req/ParentPasswordChangeReqDto.java
@@ -1,0 +1,23 @@
+package com.swyp.playground.domain.parent.dto.req;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.*;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ParentPasswordChangeReqDto {
+    @NotBlank(message = "현재 비밀번호를 입력해주세요")
+    private String currentPassword;
+
+    @NotBlank(message = "새로운 비밀번호를 입력해주세요")
+    @Pattern(regexp = "^(?=.*[A-Z])(?=.*[a-z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]{6,20}$",
+            message = "비밀번호는 6~20자 영문 대 소문자, 숫자, 특수문자를 포함해야 합니다.")
+    private String newPassword;
+
+    @NotBlank(message = "새로운 비밀번호 확인을 입력해주세요")
+    private String newPasswordConfirm;
+}

--- a/src/main/java/com/swyp/playground/domain/parent/dto/res/ParentPasswordChangeResDto.java
+++ b/src/main/java/com/swyp/playground/domain/parent/dto/res/ParentPasswordChangeResDto.java
@@ -1,0 +1,10 @@
+package com.swyp.playground.domain.parent.dto.res;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ParentPasswordChangeResDto {
+    private String message;
+}

--- a/src/main/java/com/swyp/playground/domain/parent/service/ParentService.java
+++ b/src/main/java/com/swyp/playground/domain/parent/service/ParentService.java
@@ -6,6 +6,7 @@ import com.swyp.playground.domain.child.domain.Child;
 import com.swyp.playground.domain.child.dto.req.ChildUpdateReqDto;
 import com.swyp.playground.domain.parent.domain.Parent;
 import com.swyp.playground.domain.parent.dto.req.ParentCreateReqDto;
+import com.swyp.playground.domain.parent.dto.req.ParentPasswordChangeReqDto;
 import com.swyp.playground.domain.parent.dto.req.ParentUpdateReqDto;
 import com.swyp.playground.domain.parent.dto.res.ParentCreateResDto;
 import com.swyp.playground.domain.parent.repository.ParentRepository;
@@ -179,5 +180,24 @@ public class ParentService {
         Parent parent = parentRepository.findByEmail(email)
                .orElseThrow(() -> new IllegalArgumentException("해당 이메일을 가진 사용자가 존재하지 않습니다: " + email));
         return parent.getNickname();
+    }
+    public void changePassword(Long parentId, ParentPasswordChangeReqDto request) {
+        Parent parent = parentRepository.findById(parentId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        if (!passwordEncoder.matches(request.getCurrentPassword(), parent.getPassword())) {
+            throw new IllegalArgumentException("현재 비밀번호가 일치하지 않습니다.");
+        }
+
+        if (!request.getNewPassword().equals(request.getNewPasswordConfirm())) {
+            throw new IllegalArgumentException("새로운 비밀번호가 일치하지 않습니다.");
+        }
+
+        if (request.getCurrentPassword().equals(request.getNewPassword())) {
+            throw new IllegalArgumentException("새로운 비밀번호가 현재 비밀번호와 같습니다.");
+        }
+
+        String encodedNewPassword = passwordEncoder.encode(request.getNewPassword());
+        parent.setPassword(encodedNewPassword);
     }
 }


### PR DESCRIPTION
- 비밀번호 변경 로직 추가

로그인한 상태에서 본인만 비밀번호를 변경할 수 있음
POST/ localhost:8080/auth/password/{parentId}

본인이 아닌경우

return ResponseEntity.status(403).body("자신의 비밀번호만 변경할 수 있습니다.");
